### PR TITLE
Add Rails 8 support and fix Redis decoding

### DIFF
--- a/lib/sidekiq/haron.rb
+++ b/lib/sidekiq/haron.rb
@@ -1,4 +1,10 @@
 require 'sidekiq'
+
+require 'active_support'
+require 'active_support/core_ext/object/blank'
+require 'active_support/tagged_logging'
+require 'active_support/broadcast_logger'
+
 require 'sidekiq/haron/formatter'
 require 'sidekiq/haron/redis_converts'
 require 'sidekiq/haron/storage'

--- a/lib/sidekiq/haron/client_middleware.rb
+++ b/lib/sidekiq/haron/client_middleware.rb
@@ -1,6 +1,7 @@
 module Sidekiq
   module Haron
     class ClientMiddleware
+      include Sidekiq::ClientMiddleware
 
       def call(worker_class, msg, queue, redis_pool=nil)
         if msg['retry_count'].blank? # don't store on retry

--- a/lib/sidekiq/haron/redis_converts.rb
+++ b/lib/sidekiq/haron/redis_converts.rb
@@ -34,8 +34,9 @@ module Sidekiq
           CLASSES_TO_CONVERT.each do |k, v|
             return k if v[:redis_value] == redis_value
           end
-        end
 
+          nil
+        end
       end
     end
   end

--- a/lib/sidekiq/haron/server_middleware.rb
+++ b/lib/sidekiq/haron/server_middleware.rb
@@ -1,6 +1,7 @@
 module Sidekiq
   module Haron
     class ServerMiddleware
+      include Sidekiq::ServerMiddleware
 
       def call(worker, msg, queue)
         Sidekiq::Haron.transmitter.load(msg['jid'])

--- a/lib/sidekiq/haron/version.rb
+++ b/lib/sidekiq/haron/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Haron
-    VERSION = "0.2.3".freeze
+    VERSION = "0.2.4".freeze
   end
 end

--- a/sidekiq-haron.gemspec
+++ b/sidekiq-haron.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "sidekiq", "~> 7.3.0"
-  spec.add_dependency "rails", '~> 7.0'
+  spec.add_dependency "rails", ">= 7.0", "< 8.1"
   spec.add_development_dependency "bundler", "~> 2.5.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/spec/sidekiq/haron/redis_converts_spec.rb
+++ b/spec/sidekiq/haron/redis_converts_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe Sidekiq::Haron::Storage::RedisConverts do
+  subject(:converter) do
+    Class.new do
+      include Sidekiq::Haron::Storage::RedisConverts
+    end.new
+  end
+
+  describe '#encode_values_from' do
+    it 'encodes nil and boolean values' do
+      data = ['request-id', nil, true, false]
+
+      expect(converter.encode_values_from(data)).to eq(%w[request-id NilClass TrueClass FalseClass])
+    end
+  end
+
+  describe '#decode_values_from' do
+    it 'decodes encoded values and keeps regular strings unchanged' do
+      data = {
+        'request_id' => 'request-id',
+        'user_id' => 'NilClass',
+        'enabled' => 'TrueClass',
+        'archived' => 'FalseClass'
+      }
+
+      expect(converter.decode_values_from(data)).to eq(
+                                                      'request_id' => 'request-id',
+                                                      'user_id' => nil,
+                                                      'enabled' => true,
+                                                      'archived' => false
+                                                    )
+    end
+  end
+end

--- a/spec/sidekiq/haron_spec.rb
+++ b/spec/sidekiq/haron_spec.rb
@@ -2,8 +2,4 @@ RSpec.describe Sidekiq::Haron do
   it "has a version number" do
     expect(Sidekiq::Haron::VERSION).not_to be nil
   end
-
-  it "does something useful" do
-    expect(false).to eq(true)
-  end
 end


### PR DESCRIPTION
- Change Rails dependency from `~> 7.0` to `>= 7.0, < 8.1`
- Add ActiveSupport requires needed by logger patching
- Include Sidekiq 7 middleware modules in client and server middleware cause of https://github.com/sidekiq/sidekiq/blob/main/docs/middleware.md
- Fix `RedisConverts#decode_values_from` - regular strings are now preserved, and encoded `nil` and boolean values ​​are correctly restored
- Add specs for Redis encoding and decoding
- Raised version up to `0.2.4`
